### PR TITLE
Add version: b0t-at.WinMatsch version 0.8.7 - [E2E] Add b0t-at.WinMatsch 0.8.7

### DIFF
--- a/manifests/b/b0t-at/WinMatsch/0.8.7/b0t-at.WinMatsch.installer.yaml
+++ b/manifests/b/b0t-at/WinMatsch/0.8.7/b0t-at.WinMatsch.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: b0t-at.WinMatsch
+PackageVersion: 0.8.7
+InstallerType: portable
+Installers:
+- Architecture: x64
+  InstallerUrl: https://winmatsch.oneinfra.de/v0.8.7/winmatsch-v0.8.7-win-x64.exe
+  InstallerSha256: 426198E5D55767A92AB63C8BC9BDA8D752A69F615F5C09D8C7F3CB874DF801A4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/b0t-at/WinMatsch/0.8.7/b0t-at.WinMatsch.locale.en-US.yaml
+++ b/manifests/b/b0t-at/WinMatsch/0.8.7/b0t-at.WinMatsch.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: b0t-at.WinMatsch
+PackageVersion: 0.8.7
+PackageLocale: en-US
+Publisher: b0t.at
+PublisherUrl: https://github.com/b0t-at
+PublisherSupportUrl: https://github.com/b0t-at/winmatsch/issues
+PackageName: WinMatsch
+PackageUrl: https://github.com/b0t-at/winmatsch
+License: MIT
+LicenseUrl: https://github.com/b0t-at/winmatsch/blob/v0.8.7/LICENSE
+ShortDescription: Cross-platform WinGet manifest automation.
+Description: Analyzes installers, generates and validates WinGet manifests, and supports an explicit fork-based submission workflow.
+Tags:
+- winget
+- manifests
+- automation
+ReleaseNotesUrl: https://github.com/b0t-at/winmatsch/releases/tag/v0.8.7
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/b0t-at/WinMatsch/0.8.7/b0t-at.WinMatsch.yaml
+++ b/manifests/b/b0t-at/WinMatsch/0.8.7/b0t-at.WinMatsch.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch
+
+PackageIdentifier: b0t-at.WinMatsch
+PackageVersion: 0.8.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- winmatsch:package=b0t-at.WinMatsch;version=0.8.7 -->
Created with: winmatsch
Operation: Add
Target repository: authenticated-user fork
Manifest path: `manifests/b/b0t-at/WinMatsch/0.8.7`
Dry run: False
Skip PR check: False

## Validation
Status: passed
- No findings.

## Rules
- No rule executions.
Changes: 0
Reviews: 0

## Changes
- Add: `manifests/b/b0t-at/WinMatsch/0.8.7/b0t-at.WinMatsch.installer.yaml`
- Add: `manifests/b/b0t-at/WinMatsch/0.8.7/b0t-at.WinMatsch.locale.en-US.yaml`
- Add: `manifests/b/b0t-at/WinMatsch/0.8.7/b0t-at.WinMatsch.yaml`