### PR TITLE
Add version: Utesgui.WinMatsch.EmptyPathCanary version 22.1 - WinMatsch live E2E: journaled nested ZIP empty-path regression

### DIFF
--- a/manifests/u/Utesgui/WinMatsch/EmptyPathCanary/22.1/Utesgui.WinMatsch.EmptyPathCanary.installer.yaml
+++ b/manifests/u/Utesgui/WinMatsch/EmptyPathCanary/22.1/Utesgui.WinMatsch.EmptyPathCanary.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# Created with winmatsch live E2E
+
+PackageIdentifier: Utesgui.WinMatsch.EmptyPathCanary
+PackageVersion: "22.1"
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: RoslynPad.exe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/roslynpad/roslynpad/releases/download/22.1/RoslynPad-windows-x64.zip
+  InstallerSha256: 40ACF22DC8CA71C1C2D85A7F98F0E1BEDF26D0152C89CD8493C0A5189901AA55
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/Utesgui/WinMatsch/EmptyPathCanary/22.1/Utesgui.WinMatsch.EmptyPathCanary.locale.en-US.yaml
+++ b/manifests/u/Utesgui/WinMatsch/EmptyPathCanary/22.1/Utesgui.WinMatsch.EmptyPathCanary.locale.en-US.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# Created with winmatsch live E2E
+
+PackageIdentifier: Utesgui.WinMatsch.EmptyPathCanary
+PackageVersion: "22.1"
+PackageLocale: en-US
+Publisher: Utesgui
+PublisherUrl: https://github.com/Utesgui
+PackageName: WinMatsch Empty Path Canary
+PackageUrl: https://github.com/b0t-at/winmatsch
+License: MIT
+LicenseUrl: https://github.com/b0t-at/winmatsch/blob/main/LICENSE
+ShortDescription: Disposable fork-only canary for WinMatsch journaled nested ZIP submission.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/Utesgui/WinMatsch/EmptyPathCanary/22.1/Utesgui.WinMatsch.EmptyPathCanary.yaml
+++ b/manifests/u/Utesgui/WinMatsch/EmptyPathCanary/22.1/Utesgui.WinMatsch.EmptyPathCanary.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# Created with winmatsch live E2E
+
+PackageIdentifier: Utesgui.WinMatsch.EmptyPathCanary
+PackageVersion: "22.1"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- winmatsch:package=Utesgui.WinMatsch.EmptyPathCanary;version=22.1 -->
Created with: winmatsch live E2E
Operation: Add
Target repository: authenticated-user fork
Manifest path: `manifests/u/Utesgui/WinMatsch/EmptyPathCanary/22.1`
Dry run: False
Skip PR check: False

## Validation
Status: passed
- VLD3007 [Warning]: Portable nested installers should declare a PortableCommandAlias.

## Rules
- No rule executions.
Changes: 0
Reviews: 0

## Changes
- Add: `manifests/u/Utesgui/WinMatsch/EmptyPathCanary/22.1/Utesgui.WinMatsch.EmptyPathCanary.installer.yaml`
- Add: `manifests/u/Utesgui/WinMatsch/EmptyPathCanary/22.1/Utesgui.WinMatsch.EmptyPathCanary.locale.en-US.yaml`
- Add: `manifests/u/Utesgui/WinMatsch/EmptyPathCanary/22.1/Utesgui.WinMatsch.EmptyPathCanary.yaml`