### PR TITLE
Add version: 66HEX.Frame version 0.33.0

### DIFF
--- a/manifests/6/66HEX/Frame/0.33.0/66HEX.Frame.installer.yaml
+++ b/manifests/6/66HEX/Frame/0.33.0/66HEX.Frame.installer.yaml
@@ -1,0 +1,26 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: 66HEX.Frame
+PackageVersion: 0.33.0
+InstallerLocale: en-US
+InstallerType: inno
+Scope: user
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{7D37707F-5F27-47B6-82EE-207B922EC013}_is1'
+ReleaseDate: 2026-08-04
+AppsAndFeaturesEntries:
+- Publisher: 66HEX
+  ProductCode: '{7D37707F-5F27-47B6-82EE-207B922EC013}_is1'
+InstallationMetadata:
+  DefaultInstallLocation: '%LocalAppData%\Programs\Frame'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/66HEX/frame/releases/download/0.33.0/Frame-x86_64.exe
+  InstallerSha256: 3BBBE6BBAE9F89107E4927D16359118C4AC5438E6F2FA86DB06EDF07F3C2082B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/6/66HEX/Frame/0.33.0/66HEX.Frame.locale.en-US.yaml
+++ b/manifests/6/66HEX/Frame/0.33.0/66HEX.Frame.locale.en-US.yaml
@@ -1,0 +1,40 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: 66HEX.Frame
+PackageVersion: 0.33.0
+PackageLocale: en-US
+Publisher: Marek Jóźwiak
+PublisherUrl: https://www.madebyhex.com/
+PublisherSupportUrl: https://github.com/sponsors/66HEX
+Author: Marek Jóźwiak
+PackageName: Frame
+PackageUrl: https://www.framegui.app/
+License: GPL-3.0
+LicenseUrl: https://github.com/66HEX/frame/blob/HEAD/LICENSE
+ShortDescription: Frame is a high-performance media conversion utility built on the Tauri v2 framework. It provides a native interface for FFmpeg operations
+Description: Frame is a high-performance media conversion utility built on the Tauri v2 framework. It provides a native interface for FFmpeg operations, allowing for granular control over video and audio transcoding parameters. The application leverages a Rust-based backend for concurrent task management and process execution, coupled with a Svelte 5 frontend for configuration and state monitoring.
+Moniker: frame
+Tags:
+- ffmpeg
+- ffmpeg-gui
+- macos
+- media-converter
+- rust
+- svelte
+- tauri
+- video-conversion
+ReleaseNotes: |-
+  Added
+  - M2T, MTS, and M2TS Workflows: Added complete MPEG transport-stream import, preview, re-encode, mixed subtitle, and stream-copy workflows with explicit 188-byte M2T and 192-byte MTS/M2TS profiles; MPEG-2 Video, MP2, Opus-in-TS, AC-3, and Blu-ray PCM encoding; program/service metadata Preserve, Clean, and Replace modes; SRT/ASS/WebVTT burn-in; embedded DVB/teletext/ARIB/PGS handling; and selectable .sup PGS copy or standards-compliant DVB conversion without private-data subtitle fallbacks. Resolves #111.
+  - Selectable External Subtitles: Added multi-file import for SRT, ASS, and WebVTT sidecars as switchable output tracks, with per-track language, title, default, and forced metadata. External tracks are persisted with file settings, validated before conversion, kept synchronized with trimmed exports, and encoded according to the MP4, MOV, MKV, or WebM subtitle contract without forcing source audio and video streams out of copy mode.
+  Changed
+  - Explicit Stream Selection: Audio and embedded subtitle exports now map only tracks explicitly selected by the user; an empty selection produces no stream of that type instead of implicitly preserving every source track.
+  - Virtualized File Queue: Reused the Logs panel's uniform-list rendering and scrollbar for the workspace file queue, keeping large batches responsive while preserving row selection, actions, and accessibility.
+  - Subtitle Settings Workflow: Split the Subtitles tab into Selectable and Burn-in modes so only the relevant controls are shown. Selectable subtitles now combine imported sidecars with embedded source tracks, while burn-in import uses the same post-import file-row and removal pattern as selectable subtitles.
+  - Audio and Subtitle Track Rows: Reworked shared track rows so audio metadata uses a readable two-line layout with channels, language, track name, and bitrate grouped together, while subtitle rows remain compact and preserve the track index and codec when space is limited. Source track names now fall back to FFmpeg handler metadata when no title is available.
+  Fixed
+  - Track Selection Feedback: Smoothed selected, unselected, hover, and selection-dot transitions and cleared pressed state before click handlers run, preventing track rows from retaining an incorrect brighter color until focus moved elsewhere or showing an unwanted intermediate pressed color.
+ReleaseNotesUrl: https://github.com/66HEX/frame/releases/tag/0.33.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/6/66HEX/Frame/0.33.0/66HEX.Frame.yaml
+++ b/manifests/6/66HEX/Frame/0.33.0/66HEX.Frame.yaml
@@ -1,0 +1,8 @@
+# Created with komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: 66HEX.Frame
+PackageVersion: 0.33.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
<!-- winmatsch:package=66HEX.Frame;version=0.33.0 -->
Created with: winmatsch
Operation: Add
Target repository: authenticated-user fork
Manifest path: `manifests/6/66HEX/Frame/0.33.0`
Dry run: False
Skip PR check: False

## Validation
Status: passed
- No findings.

## Rules
- No rule executions.
Changes: 0
Reviews: 0

## Changes
- Add: `manifests/6/66HEX/Frame/0.33.0/66HEX.Frame.installer.yaml`
- Add: `manifests/6/66HEX/Frame/0.33.0/66HEX.Frame.locale.en-US.yaml`
- Add: `manifests/6/66HEX/Frame/0.33.0/66HEX.Frame.yaml`